### PR TITLE
First cut at implementing invert() and inverted() for poses

### DIFF
--- a/include/kindr/poses/PoseBase.hpp
+++ b/include/kindr/poses/PoseBase.hpp
@@ -136,6 +136,17 @@ class PoseBase {
    *  \returns reference
    */
   Derived_& setIdentity();
+
+  /*! \brief Returns the inverse of the pose
+   *  \returns inverse of the pose
+   */
+  PoseBase inverted() const;
+
+  /*! \brief Inverts the pose
+   *  \returns reference
+   */
+  PoseBase& invert();
+
 };
 
 /*! \class HomogeneousTransformationBase

--- a/include/kindr/poses/PoseBase.hpp
+++ b/include/kindr/poses/PoseBase.hpp
@@ -161,6 +161,7 @@ class TransformationBase {
   Derived_& invert() {
     derived().getPosition() = -derived().getRotation().inverseRotate(derived().getPosition());
     derived().getRotation().invert();
+    return *this;
   }
 
   /*! \brief Returns the pose in a unique form

--- a/include/kindr/poses/eigen/HomogeneousTransformation.hpp
+++ b/include/kindr/poses/eigen/HomogeneousTransformation.hpp
@@ -100,6 +100,23 @@ class HomogeneousTransformation : public HomogeneousTransformationBase<Homogeneo
     Rotation::setIdentity();
     return *this;
   }
+
+  /*! \brief Returns the inverse of the rotation
+   *  \returns inverse of the rotation
+   */
+  HomogeneousTransformation inverted() const {
+    return HomogeneousTransformation( -getRotation().rotate(getPosition()), getRotation().inverted() );
+  }
+
+  /*! \brief Inverts the rotation.
+   *  \returns reference
+   */
+  HomogeneousTransformation& invert() { 
+    getPosition() = -getRotation().rotate(getPosition());
+    getRotation().invert();
+  }
+
+
 };
 
 template<typename PrimType_>

--- a/include/kindr/poses/eigen/HomogeneousTransformation.hpp
+++ b/include/kindr/poses/eigen/HomogeneousTransformation.hpp
@@ -43,36 +43,40 @@ namespace eigen_impl {
 
 
 template<typename PrimType_, typename Position_, typename Rotation_>
-class HomogeneousTransformation : public HomogeneousTransformationBase<HomogeneousTransformation<PrimType_, Position_, Rotation_>>, private Position_, private Rotation_ {
+class HomogeneousTransformation : public TransformationBase<HomogeneousTransformation<PrimType_, Position_, Rotation_>> {
  public:
 
   typedef PrimType_ Scalar;
   typedef Position_ Position;
   typedef Rotation_ Rotation;
   typedef Eigen::Matrix<PrimType_, 4, 4> TransformationMatrix;
-
+  
+private:
+  Position position_;
+  Rotation rotation_;
+public:
 
   HomogeneousTransformation() = default;
 
   HomogeneousTransformation(const Position& position, const Rotation& rotation) :
-    Position(position),Rotation(rotation) {
+    position_(position), rotation_(rotation) {
   }
 
 
   inline Position_ & getPosition() {
-    return static_cast<Position_ &>(*this);
+    return position_;
   }
 
   inline const Position_ & getPosition() const {
-    return static_cast<const Position_ &>(*this);
+    return position_;
   }
 
   inline Rotation_ & getRotation() {
-    return static_cast<Rotation_ &>(*this);
+    return rotation_;
   }
 
   inline const Rotation_ & getRotation() const {
-    return static_cast<const Rotation_ &>(*this);
+    return rotation_;
   }
 
 
@@ -92,29 +96,8 @@ class HomogeneousTransformation : public HomogeneousTransformationBase<Homogeneo
     return out;
   }
 
-  /*! \brief Sets the pose to identity
-   *  \returns reference
-   */
-  HomogeneousTransformation& setIdentity() {
-    Position::setZero();
-    Rotation::setIdentity();
-    return *this;
-  }
 
-  /*! \brief Returns the inverse of the rotation
-   *  \returns inverse of the rotation
-   */
-  HomogeneousTransformation inverted() const {
-    return HomogeneousTransformation( -getRotation().rotate(getPosition()), getRotation().inverted() );
-  }
 
-  /*! \brief Inverts the rotation.
-   *  \returns reference
-   */
-  HomogeneousTransformation& invert() { 
-    getPosition() = -getRotation().rotate(getPosition());
-    getRotation().invert();
-  }
 
 
 };
@@ -136,8 +119,9 @@ class HomogeneousTransformationPosition3RotationQuaternion: public HomogeneousTr
 
 };
 
-typedef HomogeneousTransformationPosition3RotationQuaternion<double> HomogeneousTransformationPosition3RotationQuaternionD;
-typedef HomogeneousTransformationPosition3RotationQuaternion<float> HomogeneousTransformationPosition3RotationQuaternionF;
+typedef HomogeneousTransformation<double, phys_quant::eigen_impl::Position<double, 3>, rotations::eigen_impl::RotationQuaternion<double, rotations::RotationUsage::PASSIVE>> HomogeneousTransformationPosition3RotationQuaternionD;
+
+typedef HomogeneousTransformation<float, phys_quant::eigen_impl::Position<float, 3>, rotations::eigen_impl::RotationQuaternion<float, rotations::RotationUsage::PASSIVE>> HomogeneousTransformationPosition3RotationQuaternionF;
 
 
 } // namespace eigen_impl
@@ -157,12 +141,7 @@ class TransformationTraits<eigen_impl::HomogeneousTransformation<PrimType_, Posi
   typedef typename eigen_impl::HomogeneousTransformation<PrimType_, Position_, Rotation_> Pose;
   typedef typename get_position<Pose>::Position Position;
  public:
-  inline static Position transform(const Pose & pose, const Position & position){
-    return pose.getRotation().rotate(position) + pose.getPosition();
-  }
-  inline static Position inverseTransform(const Pose & pose, const Position & position){
-    return pose.getRotation().inverseRotate((position-pose.getPosition()));
-  }
+
 };
 
 

--- a/test/poses/PoseDiffEigenTest.cpp
+++ b/test/poses/PoseDiffEigenTest.cpp
@@ -1,5 +1,4 @@
 /*
-  /*
  * Copyright (c) 2013, Christian Gehring, Hannes Sommer, Paul Furgale, Remo Diethelm
  * All rights reserved.
  *

--- a/test/poses/PoseEigenTest.cpp
+++ b/test/poses/PoseEigenTest.cpp
@@ -106,25 +106,40 @@ TYPED_TEST(HomogeneousTransformationTest, testGenericRotateVectorCompilable)
   test.getRotation().rotate(vel);
 }
 
-TYPED_TEST(HomogeneousTransformationTest, testInvert)
+#define COUT_P(x) std::cout << #x << std::endl << x << std::endl;
+
+
+TYPED_TEST(HomogeneousTransformationTest, testInverted)
 {
   typedef typename TestFixture::Pose Pose;
   typedef typename Pose::Position Position;
   typedef typename Pose::Rotation Rotation;
-  Pose T_A_B( Position(1,2,3), Rotation(rot::AngleAxisPD(0.5,1.0,0.1,0.2)));
-  
-  Pose T_B_A = T_A_B.inverted();
-  
-  Pose Identity = T_A_B * T_B_A;
-  ASSERT_EQ(Identity.getPosition().vector().x(), 0);
-  ASSERT_EQ(Identity.getPosition().vector().y(), 0);
-  ASSERT_EQ(Identity.getPosition().vector().z(), 0);
+  typedef typename Pose::Scalar Scalar;
+  typedef typename Eigen::Matrix<Scalar, 4, 4> Matrix4d;
+  Pose T_A_B( Position(11,22,33), Rotation(rot::AngleAxisPD(0.5,1.0,0.1,0.2)));
+  Matrix4d mT_A_B = T_A_B.getTransformationMatrix();
+  Matrix4d invmT_B_A = mT_A_B.inverse();
 
-  ASSERT_EQ(Identity.getRotation().w(), 1);
-  ASSERT_EQ(Identity.getRotation().x(), 0);
-  ASSERT_EQ(Identity.getRotation().y(), 0);
-  ASSERT_EQ(Identity.getRotation().z(), 0);
+  Pose T_B_A = T_A_B.inverted();
+  Matrix4d mT_B_A = T_B_A.getTransformationMatrix();
+  
+  COUT_P(T_A_B);
+  COUT_P(mT_A_B);
+  COUT_P(mT_A_B.inverse());
+  COUT_P(T_B_A);
+  COUT_P(mT_B_A);
+
+  for(int r = 0; r < 4; ++r) {
+    for(int c = 0; c < 4; ++c) {
+      ASSERT_NEAR( invmT_B_A(r,c), mT_B_A(r,c), 1e-2) << 
+          "Comparing matrix inverse:\n" << invmT_B_A << 
+          "\nwith Transformation inverse:\n" << mT_B_A <<
+          "\nComparison failed at (" << r << "," << c << ")" << std::endl;
+    }
+  }
+
 }
+
 
 
 

--- a/test/poses/PoseEigenTest.cpp
+++ b/test/poses/PoseEigenTest.cpp
@@ -1,5 +1,4 @@
 /*
-  /*
  * Copyright (c) 2013, Christian Gehring, Hannes Sommer, Paul Furgale, Remo Diethelm
  * All rights reserved.
  *
@@ -106,5 +105,26 @@ TYPED_TEST(HomogeneousTransformationTest, testGenericRotateVectorCompilable)
   pos::Velocity3D vel(-1,2,3);
   test.getRotation().rotate(vel);
 }
+
+TYPED_TEST(HomogeneousTransformationTest, testInvert)
+{
+  typedef typename TestFixture::Pose Pose;
+  typedef typename Pose::Position Position;
+  typedef typename Pose::Rotation Rotation;
+  Pose T_A_B( Position(1,2,3), Rotation(rot::AngleAxisPD(0.5,1.0,0.1,0.2)));
+  
+  Pose T_B_A = T_A_B.inverted();
+  
+  Pose Identity = T_A_B * T_B_A;
+  ASSERT_EQ(Identity.getPosition().vector().x(), 0);
+  ASSERT_EQ(Identity.getPosition().vector().y(), 0);
+  ASSERT_EQ(Identity.getPosition().vector().z(), 0);
+
+  ASSERT_EQ(Identity.getRotation().w(), 1);
+  ASSERT_EQ(Identity.getRotation().x(), 0);
+  ASSERT_EQ(Identity.getRotation().y(), 0);
+  ASSERT_EQ(Identity.getRotation().z(), 0);
+}
+
 
 

--- a/test/positions/PositionDiffEigenTest.cpp
+++ b/test/positions/PositionDiffEigenTest.cpp
@@ -1,5 +1,4 @@
 /*
-  /*
  * Copyright (c) 2013, Christian Gehring, Hannes Sommer, Paul Furgale, Remo Diethelm
  * All rights reserved.
  *

--- a/test/positions/PositionEigenTest.cpp
+++ b/test/positions/PositionEigenTest.cpp
@@ -1,5 +1,4 @@
 /*
-  /*
  * Copyright (c) 2013, Christian Gehring, Hannes Sommer, Paul Furgale, Remo Diethelm
  * All rights reserved.
  *


### PR DESCRIPTION
DO NOT MERGE, this is for discussion only.

@HannesSommer, I need your help with this. 

This fails to compile because inverted() returns the wrong type. The compiler is right about this because the class hierarchy looks like:

PoseBase --> HomogeneousTransformation --> HomogeneousTransformationPosition3RotationQuaternion

How is HomogeneousTransformation supposed to know what type to return?

Thanks!