### PR TITLE
Feature/catkin compliant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,12 @@ project(kindr)
 #set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 #set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
+
+find_package(Eigen3 REQUIRED)
+
+include_directories(include)
+include_directories(${EIGEN3_INCLUDE_DIR})
 
 # Noisily default to Release build
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -59,6 +65,9 @@ endif()
 
 # Add CMake module path
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+
+
+install(DIRECTORY include/kindr DESTINATION include)
 
 # Add common
 #add_subdirectory(common)
@@ -90,18 +99,18 @@ add_subdirectory(doc/doxygen)
 ADD_CUSTOM_TARGET(demo DEPENDS demo_rotations)
 
 # Generate FindKindr.cmake file
-file(WRITE cmake/FindKindr.cmake
-"# This file was automatically generated during the installation of the Kindr library
-# and can be used through cmake to find the corresponding header files. A copy of this
-# file was created in ${CMAKE_ROOT}/Modules (depending on the CMAKE_ROOT variable).
+#  file(WRITE cmake/FindKindr.cmake
+#  "# This file was automatically generated during the installation of the Kindr library
+  # and can be used through cmake to find the corresponding header files. A copy of this
+  # file was created in ${CMAKE_ROOT}/Modules (depending on the CMAKE_ROOT variable).
 
-set(Kindr_INCLUDE_DIRS
-${CMAKE_INSTALL_PREFIX}/include/Kindr/include
-)
-set(Kindr_FOUND TRUE)
-#message(\"-- Kindr found (include: ${CMAKE_INSTALL_PREFIX}/include/Kindr/include)\")
-"
-)
+#  set(Kindr_INCLUDE_DIRS
+#  ${CMAKE_INSTALL_PREFIX}/include/Kindr/include
+#  )
+#  set(Kindr_FOUND TRUE)
+  #message(\"-- Kindr found (include: ${CMAKE_INSTALL_PREFIX}/include/Kindr/include)\")
+#  "
+#)
 
 # Setting for make install
 #install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_INSTALL_PREFIX}/include/Kindr)")
@@ -131,6 +140,7 @@ export(PACKAGE kindr)
 
 # Create variable for the local build tree
 get_property(kindr_include_dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
+
 # Configure config file for local build tree
 configure_file(kindrConfig.cmake.in
   "${PROJECT_BINARY_DIR}/kindrConfig.cmake" @ONLY)
@@ -140,13 +150,10 @@ configure_file(kindrConfig.cmake.in
 # Change the include location for the case of an install location
 set(kindr_include_dirs ${CMAKE_INSTALL_PREFIX}/include)
 
+
 # We put the generated file for installation in a different repository (i.e., ./CMakeFiles/)
 configure_file(kindrConfig.cmake.in
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/kindrConfig.cmake" @ONLY)
-
-# The same versioning file can be used for both cases
-configure_file(kindrConfigVersion.cmake.in
-  "${PROJECT_BINARY_DIR}/kindrConfigVersion.cmake" @ONLY)
 
 install(FILES
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/kindrConfig.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,63 @@ set(Kindr_FOUND TRUE)
 )
 
 # Setting for make install
-install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_INSTALL_PREFIX}/include/Kindr)")
-install(DIRECTORY include DESTINATION ${CMAKE_INSTALL_PREFIX}/include/Kindr)
-install(FILES cmake/FindKindr.cmake DESTINATION ${CMAKE_ROOT}/Modules)
+#install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_INSTALL_PREFIX}/include/Kindr)")
+#install(DIRECTORY include DESTINATION ${CMAKE_INSTALL_PREFIX}/include/Kindr OPTIONAL)
+#install(FILES cmake/FindKindr.cmake DESTINATION ${CMAKE_ROOT}/Modules)
 
+# Install catkin package.xml
+install(FILES package.xml DESTINATION share/kindr)
+
+
+#=============================================
+# to allow find_package() on kindr
+#=============================================
+# 
+# the following case be used in an external project requiring kindr:
+#  ...
+#  find_package(kindr) 
+#  include_directories(${kindr_INCLUDE_DIRS}) 
+#  ...
+
+# NOTE: the following will support find_package for 1) local build (make) and 2) for installed files (make install)
+
+# 1- local build #
+
+# Register the local build in case one doesn't use "make install"
+export(PACKAGE kindr)
+
+# Create variable for the local build tree
+get_property(kindr_include_dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
+# Configure config file for local build tree
+configure_file(kindrConfig.cmake.in
+  "${PROJECT_BINARY_DIR}/kindrConfig.cmake" @ONLY)
+
+# 2- installation build #
+
+# Change the include location for the case of an install location
+set(kindr_include_dirs ${CMAKE_INSTALL_PREFIX}/include)
+
+# We put the generated file for installation in a different repository (i.e., ./CMakeFiles/)
+configure_file(kindrConfig.cmake.in
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/kindrConfig.cmake" @ONLY)
+
+# The same versioning file can be used for both cases
+configure_file(kindrConfigVersion.cmake.in
+  "${PROJECT_BINARY_DIR}/kindrConfigVersion.cmake" @ONLY)
+
+install(FILES
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/kindrConfig.cmake"
+  DESTINATION share/kindr/cmake COMPONENT dev)
+
+
+
+#=============================================
+# Add uninstall target
+#=============================================
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,6 @@ cmake_minimum_required (VERSION 2.8)
 
 project(kindr)
 
-#set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
-#set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
 
@@ -69,53 +67,13 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 install(DIRECTORY include/kindr DESTINATION include)
 
-# Add common
-#add_subdirectory(common)
-
-# Add linear algebra 
-#add_subdirectory(linear_algebra)
-
-# Add quaternions
-#add_subdirectory(quaternions)
-
-# Add rotations
-#add_subdirectory(rotations)
-
-# Add positions
-#add_subdirectory(positions)
-
-# Add poses
-#add_subdirectory(poses)
-
-# Add test
+# Add unit tests
 if(BUILD_GTEST)
 	add_subdirectory(test)
 endif()
 
-
 # Add Doxygen documentation
 add_subdirectory(doc/doxygen)
-
-ADD_CUSTOM_TARGET(demo DEPENDS demo_rotations)
-
-# Generate FindKindr.cmake file
-#  file(WRITE cmake/FindKindr.cmake
-#  "# This file was automatically generated during the installation of the Kindr library
-  # and can be used through cmake to find the corresponding header files. A copy of this
-  # file was created in ${CMAKE_ROOT}/Modules (depending on the CMAKE_ROOT variable).
-
-#  set(Kindr_INCLUDE_DIRS
-#  ${CMAKE_INSTALL_PREFIX}/include/Kindr/include
-#  )
-#  set(Kindr_FOUND TRUE)
-  #message(\"-- Kindr found (include: ${CMAKE_INSTALL_PREFIX}/include/Kindr/include)\")
-#  "
-#)
-
-# Setting for make install
-#install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_INSTALL_PREFIX}/include/Kindr)")
-#install(DIRECTORY include DESTINATION ${CMAKE_INSTALL_PREFIX}/include/Kindr OPTIONAL)
-#install(FILES cmake/FindKindr.cmake DESTINATION ${CMAKE_ROOT}/Modules)
 
 # Install catkin package.xml
 install(FILES package.xml DESTINATION share/kindr)

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,6 @@
 Kindr - Kinematics and Dynamics for Robotics
------------------------------------------------------------------
+============================================
+
 Autonomous Systems Lab
 ETH Zurich
 
@@ -11,62 +12,74 @@ Date     : 08-Aug-2013
 
 [![Build Status](http://129.132.38.183:8080/job/kindr/badge/icon)](http://129.132.38.183:8080/job/kindr/)
 
-DOCUMENTATION
------------------------------------------------------------------
+## Documentation
+
 [Online](http://ethz-asl-lr.bitbucket.org/kindr)
 
 Impatient individuals can directly download the [cheat sheet](http://ethz-asl-lr.bitbucket.org/kindr/cheatsheet_latest.pdf).
 
 See also section 'Building the documentation' below.
 
-REQUIREMENTS
------------------------------------------------------------------
-Linux
------------------------------
+## Requirements
+
+### Linux
 GCC 4.7 is required at the minimum.
 
-INSTALLATION
------------------------------------------------------------------
-Building the library:
------------------------------
-Build the library with CMake:
+## Installation
+
+### Building with CMake
+
+Install the library with [CMake](www.cmake.org):
+
 ```bash
-kindr$ mkdir build
-kindr$ cd build
-kindr$ cmake ..
-kindr$ make
-kindr$ sudo make install
+mkdir build
+cd build
+cmake ..
+sudo make install
 ```
 
-Building the documentation:
------------------------------
-Doxygen needs to be installed to create the documentation.
+Uninstall the library with:
 
-Build the documentation with doxygen:
 ```bash
-kindr$ mkdir build
-kindr$ cd build
-kindr$ cmake ..
-kindr$ make doc
+cd build
+sudo sudo make uninstall
+```
+
+Kindr can be included in your cmake project with:
+
+```
+find_package(kindr) 
+include_directories(${kindr_INCLUDE_DIRS}) 
+```
+
+### Building the documentation
+
+Build the documentation with [Doxygen](www.doxygen.org):
+```bash
+mkdir build
+cd build
+cmake ..
+make doc
 ```
 
 The doxygen documentation can be found here:
 
-kindr$ doc/doxygen/doc/html/index.html
+```
+doc/doxygen/doc/html/index.html
+```
 
+### Building unit tests with gtest
 
-Building google tests
------------------------------
-GTests are built as soon as the folder gtest exists in the root folder.
+[GTests](https://code.google.com/p/googletest/) are only built if the folder *gtest* exists in the root folder.
 
 Download and use GTest:
 
 ```bash
-kindr$ wget http://googletest.googlecode.com/files/gtest-1.7.0.zip
-kindr$ unzip gtest-1.7.0.zip
-kindr$ ln -s gtest-1.7.0 gtest
-kindr$ mkdir build
-kindr$ cd build
-kindr$ cmake -DBUILD_TEST=true ..
-kindr$ make
+wget http://googletest.googlecode.com/files/gtest-1.7.0.zip
+unzip gtest-1.7.0.zip
+ln -s gtest-1.7.0 gtest
+mkdir build
+cd build
+cmake  .. -DBUILD_TEST=true
+make
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -73,7 +73,7 @@ catkin build -w ~/catkin_ws kindr
 ```
 
 Kindr can be included in your catkin project with:
-Add the following to your *CmakeLists.txt*:
+Add the following to your *CMakeLists.txt*:
 
 ```
 find_package(catkin COMPONENTS kindr) 

--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,7 @@ GCC 4.7 is required at the minimum.
 
 ## Installation
 
-### Building with CMake
+### Building with cmake
 
 Install the library with [CMake](www.cmake.org):
 
@@ -45,12 +45,50 @@ cd build
 sudo sudo make uninstall
 ```
 
-Kindr can be included in your cmake project with:
+Kindr can be included in your cmake project.
+Add the following to your *CmakeLists.txt*:
 
 ```
 find_package(kindr) 
 include_directories(${kindr_INCLUDE_DIRS}) 
 ```
+
+### Building with catkin
+
+Build kindr with [catkin](wiki.ros.org/catkin):
+
+```bash
+cd ~/catkin_ws/src
+git clone git@github.com:ethz-asl/kindr.git
+catkin_make_isolated -C ~/catkin_ws
+
+```
+
+or with [catkin command line tools](http://catkin-tools.readthedocs.org):
+
+```bash
+cd ~/catkin_ws/src
+git clone git@github.com:ethz-asl/kindr.git
+catkin build -w ~/catkin_ws kindr
+```
+
+Kindr can be included in your catkin project with:
+Add the following to your *CmakeLists.txt*:
+
+```
+find_package(catkin COMPONENTS kindr) 
+include_directories(${catkin_INCLUDE_DIRS}) 
+```
+
+And to your *package.xml*:
+
+```xml
+<package>
+	<build_depend>kindr</build_depend>
+</package>
+```
+
+
 
 ### Building the documentation
 

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,23 @@
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+    "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+    OUTPUT_VARIABLE rm_out
+    RETURN_VALUE rm_retval
+    )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+    else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+      message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)
+
+

--- a/kindrConfig.cmake.in
+++ b/kindrConfig.cmake.in
@@ -1,0 +1,10 @@
+# - Config file for the kindr package
+# It defines the following variables
+#  kindr_INCLUDE_DIRS - include directories for kindr
+ 
+# Compute paths
+get_filename_component(kindr_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(kindr_INCLUDE_DIRS "@kindr_include_dirs@")
+
+# This causes catkin_simple to link against these libraries
+set(kindr_FOUND_CATKIN_PROJECT true)

--- a/package.xml
+++ b/package.xml
@@ -1,22 +1,25 @@
 <?xml version="1.0"?>
 <package>
-<name>kindr</name>
-<version>0.0.0</version>
-<description>
- Kinematics and Dynamics for Robotics
-</description>
-<maintainer email="gehrinch@ethz.ch">Christian Gehring</maintainer>
-<license>BSD</license>
-<url type="repository">https://github.com/ethz-asl/kindr</url>
-<author email="gehrinch@ethz.ch">Christian Gehring</author>
-
-<!-- The *_depend tags are used to specify dependencies -->
-<buildtool_depend>cmake</buildtool_depend>
-<build_depend>eigen</build_depend>
-<run_depend>eigen</run_depend>
-<run_depend>catkin</run_depend>
-<export>
-<!-- Specify that this is not really a ROS package-->
-<build_type>cmake</build_type>
-</export>
+	<name>kindr</name>
+	<version>0.0.0</version>
+	<description>
+	 	Kinematics and Dynamics for Robotics
+	</description>
+	<license>BSD</license>
+	<url type="repository">https://github.com/ethz-asl/kindr</url>
+	<maintainer email="gehrinch@ethz.ch">Christian Gehring</maintainer>
+	<author>Michael Bloesch</author>
+	<author>Péter Fankhauser</author>
+	<author>Paul Furgale</author>
+	<author>Christian Gehring</author>
+	<author>Hannes Sommer</author>
+	<!-- The *_depend tags are used to specify dependencies -->
+	<buildtool_depend>cmake</buildtool_depend>
+	<build_depend>eigen</build_depend>
+	<run_depend>eigen</run_depend>
+	<run_depend>catkin</run_depend>
+	<export>
+		<!-- Specify that this is not really a ROS package-->
+		<build_type>cmake</build_type>
+	</export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package>
+<name>kindr</name>
+<version>0.0.0</version>
+<description>
+ Kinematics and Dynamics for Robotics
+</description>
+<maintainer email="gehrinch@ethz.ch">Christian Gehring</maintainer>
+<license>BSD</license>
+<url type="repository">https://github.com/ethz-asl/kindr</url>
+<author email="gehrinch@ethz.ch">Christian Gehring</author>
+
+<!-- The *_depend tags are used to specify dependencies -->
+<buildtool_depend>cmake</buildtool_depend>
+<build_depend>eigen</build_depend>
+<run_depend>eigen</run_depend>
+<run_depend>catkin</run_depend>
+<export>
+<!-- Specify that this is not really a ROS package-->
+<build_type>cmake</build_type>
+</export>
+</package>


### PR DESCRIPTION
@furgalep, this is another trial for catkin compatibility.
@simonlynen, this version works with plain cmake:

```
mkdir build && cd build
cmake ..
sudo make install
```
and then
```
find_package(kindr)
include_directories(${kindr_INCLUDE_DIRS})
```

However, how do include it in a catkin package?
If kindr is added to the catkin workspace, then the workspace can only be built with ```catkin_make_isolated```.
How did you do this with libnabo?

The main goal is to use kindr without polluting the system if catkin is used and to make it usable for building other catkin packages that depend on kindr  on jenkins.

