### PR TITLE
asserts on Quaternions now consistently cast the tolerance to scalar type

### DIFF
--- a/include/kindr/common/assert_macros_eigen.hpp
+++ b/include/kindr/common/assert_macros_eigen.hpp
@@ -45,7 +45,7 @@ using std::max;
 using std::min;
 
 template<typename SCALAR>
-inline bool compareRelative(SCALAR a, SCALAR b, double percentTolerance, SCALAR * percentError = NULL, SCALAR bothZeroThreshold = SCALAR(1.0e-15))
+inline bool compareRelative(SCALAR a, SCALAR b, SCALAR percentTolerance, SCALAR * percentError = NULL, SCALAR bothZeroThreshold = SCALAR(1.0e-15))
 {
   // \todo: does anyone have a better idea?
   SCALAR fa = abs(a);

--- a/include/kindr/quaternions/Quaternion.hpp
+++ b/include/kindr/quaternions/Quaternion.hpp
@@ -316,7 +316,7 @@ class UnitQuaternion : public UnitQuaternionBase<UnitQuaternion<PrimType_>> {
    */
   UnitQuaternion(Scalar w, Scalar x, Scalar y, Scalar z)
     : unitQuternion_(w,x,y,z) {
-    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, norm(), static_cast<Scalar>(1.0), 1e-2, "Input quaternion has not unit length.");
+    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, norm(), static_cast<Scalar>(1.0), static_cast<Scalar>(1e-2), "Input quaternion has not unit length.");
   }
 
   /*! \brief Constructor using real and imaginary part.
@@ -326,7 +326,7 @@ class UnitQuaternion : public UnitQuaternionBase<UnitQuaternion<PrimType_>> {
    */
   UnitQuaternion(Scalar real, const Imaginary& imag)
     : unitQuternion_(real,imag) {
-    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, norm(), static_cast<Scalar>(1.0), 1e-2, "Input quaternion has not unit length.");
+    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, norm(), static_cast<Scalar>(1.0), static_cast<Scalar>(1e-2), "Input quaternion has not unit length.");
   }
 
   /*! \brief Constructor using Eigen::Matrix<PrimType_,4,1>.
@@ -335,13 +335,13 @@ class UnitQuaternion : public UnitQuaternionBase<UnitQuaternion<PrimType_>> {
    */
   UnitQuaternion(const Vector4& vector4)
     : unitQuternion_(vector4(0),vector4(1),vector4(2),vector4(3)) {
-    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, norm(), static_cast<Scalar>(1.0), 1e-2, "Input quaternion has not unit length.");
+    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, norm(), static_cast<Scalar>(1.0), static_cast<Scalar>(1e-2), "Input quaternion has not unit length.");
   }
 
   //! Constructor to create unit quaternion from Quaternion
   explicit UnitQuaternion(const Quaternion<PrimType_>& other)
     : unitQuternion_(other.toImplementation()) {
-    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, norm(), static_cast<Scalar>(1.0), 1e-2, "Input quaternion has not unit length.");
+    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, norm(), static_cast<Scalar>(1.0), static_cast<Scalar>(1e-2), "Input quaternion has not unit length.");
   }
 
   //! Constructor to create unit quaternion from Eigen::Quaternion
@@ -350,7 +350,7 @@ class UnitQuaternion : public UnitQuaternionBase<UnitQuaternion<PrimType_>> {
    */
   explicit UnitQuaternion(const Implementation& other)
     : unitQuternion_(other) {
-    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, norm(), static_cast<Scalar>(1.0), 1e-2, "Input quaternion has not unit length.");
+    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, norm(), static_cast<Scalar>(1.0), static_cast<Scalar>(1e-2), "Input quaternion has not unit length.");
   }
 
   UnitQuaternion& operator =(const UnitQuaternion<PrimType_>& other) {

--- a/include/kindr/rotations/RotationQuaternion.hpp
+++ b/include/kindr/rotations/RotationQuaternion.hpp
@@ -112,7 +112,7 @@ class RotationQuaternion : public RotationBase<RotationQuaternion<PrimType_>> {
    */
   RotationQuaternion(const Vector4 & vec)
     : rotationQuaternion_(vec(0),vec(1),vec(2),vec(3)) {
-    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, rotationQuaternion_.norm(), static_cast<Scalar>(1), 1e-2, "Input quaternion has not unit length.");
+    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, rotationQuaternion_.norm(), static_cast<Scalar>(1), static_cast<Scalar>(1e-2), "Input quaternion has not unit length.");
   }
 
   /*! \brief Constructor using Eigen::Quaternion<PrimType_>.
@@ -121,7 +121,7 @@ class RotationQuaternion : public RotationBase<RotationQuaternion<PrimType_>> {
    */
   explicit RotationQuaternion(const Implementation& other)
     : rotationQuaternion_(other.w(), other.x(), other.y(), other.z()) {
-    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, rotationQuaternion_.norm(), static_cast<Scalar>(1), 1e-2, "Input quaternion has not unit length.");
+    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, rotationQuaternion_.norm(), static_cast<Scalar>(1), static_cast<Scalar>(1e-2), "Input quaternion has not unit length.");
   }
 
   /*! \brief Constructor using UnitQuaternion.
@@ -130,7 +130,7 @@ class RotationQuaternion : public RotationBase<RotationQuaternion<PrimType_>> {
    */
   explicit RotationQuaternion(const Base& other)
     : rotationQuaternion_(other.w(), other.x(), other.y(), other.z()) {
-    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, rotationQuaternion_.norm(), static_cast<Scalar>(1), 1e-2, "Input quaternion has not unit length.");
+    KINDR_ASSERT_SCALAR_NEAR_DBG(std::runtime_error, rotationQuaternion_.norm(), static_cast<Scalar>(1), static_cast<Scalar>(1e-2), "Input quaternion has not unit length.");
   }
 
   /*! \brief Constructor using another rotation.


### PR DESCRIPTION
The asserts to check whether a quaternion is a unit quaternion etc. use a tolerance. This tolerance was inconsistently (implicitly) defined as a double (see e.g. include/kindr/rotations/RotationQuaternion.hpp:115) or explicitly static_cast'ed to SCALAR type  see e.g. include/kindr/rotations/RotationQuaternion.hpp:106).

This fix consistently casts them to SCALAR type and changes the parameter of the macro helper function to SCALAR type.

I believe this is better than using double as a tolerance since comparing two SCALARs does not necessarily yield a double but more likely a SCALAR.