### PR TITLE
RotationQuaternion: Scalar fixes, wrong sign in Taylor approximation

### DIFF
--- a/include/kindr/rotations/RotationQuaternion.hpp
+++ b/include/kindr/rotations/RotationQuaternion.hpp
@@ -518,11 +518,11 @@ class ConversionTraits<RotationQuaternion<DestPrimType_>, RotationVector<SourceP
     Scalar theta = (Scalar)rotationVector.toImplementation().norm();
 
     // na is 1/theta sin(theta/2)
-    double na;
+    Scalar na;
     if(isLessThenEpsilons4thRoot(theta))
     {
-        const Scalar one_over_48 = 1.0/48.0;
-        na = 0.5 + (theta * theta) * one_over_48;
+        const Scalar one_over_48 = Scalar(1.0/48.0);
+        na = Scalar(0.5) - (theta * theta) * one_over_48;
     }
     else
     {


### PR DESCRIPTION
Double type does not work when using primitive types that cannot implicitly be converted to and from double.
The Taylor approximation has the wrong sign in my opinion.