### PR TITLE
Fix/build unit test

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -162,9 +162,9 @@ doc/html/index.html
 Download and use GTest:
 
 ```bash
-wget http://googletest.googlecode.com/files/gtest-1.7.0.zip
-unzip gtest-1.7.0.zip
-ln -s gtest-1.7.0 gtest
+wget https://github.com/google/googletest/archive/release-1.7.0.zip
+unzip release-1.7.0.zip
+ln -s googletest-release-1.7.0 gtest
 mkdir build
 cd build
 cmake .. -DBUILD_TEST=true

--- a/include/kindr/rotations/RotationQuaternionDiff.hpp
+++ b/include/kindr/rotations/RotationQuaternionDiff.hpp
@@ -42,7 +42,7 @@ namespace kindr {
 /*! \class RotationQuaternionDiff
  * \brief Time derivative of a rotation quaternion.
  *
- * This class implements the time derivative of a rotation quaterion using a Quaternion<Scalar> as data storage.
+ * This class implements the time derivative of a rotation quaternion using a Quaternion<Scalar> as data storage.
  *
  * \tparam PrimType_  Primitive data type of the coordinates.
  * \ingroup rotations
@@ -167,12 +167,11 @@ class RotationQuaternionDiff : public RotationDiffBase<RotationQuaternionDiff<Pr
     return *this;
   }
 
-
   /*! \brief Used for printing the object with std::cout.
    *  \returns std::stream object
    */
   friend std::ostream& operator << (std::ostream& out, const RotationQuaternionDiff& diff) {
-    out << static_cast<const Base&>(diff).toImplementation();
+    out << diff.w() << " " << diff.x() << " " << diff.y() << " " << diff.z();
     return out;
   }
 };

--- a/jenkins-pipeline
+++ b/jenkins-pipeline
@@ -1,2 +1,2 @@
 library 'continuous_integration_pipeline'
-ciPipeline('--cmake-args="-DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TEST=true" --no-tests --enable-doxygen --publish-doxygen')
+ciPipeline('--cmake-args="-DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TEST=true" --enable-doxygen --publish-doxygen')


### PR DESCRIPTION
I tried running the gtest, but compilation failed due to the ostream operator overload (fixed, see below). Can it be that the build server is not running the tests?